### PR TITLE
fix!: harden SMG TLS, credentials, and blocklist actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.7
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2018-2025 Splunk Inc.
+   Copyright (c) 2018-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Symantec Messaging Gateway
-Copyright (c) 2018-2025 Splunk Inc.
+Copyright (c) 2018-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Symantec Messaging Gateway
 
-Publisher: Splunk \
-Connector Version: 2.0.8 \
-Product Vendor: Symantec \
-Product Name: Messaging Gateway \
+Publisher: Splunk <br>
+Connector Version: 2.0.8 <br>
+Product Vendor: Symantec <br>
+Product Name: Messaging Gateway <br>
 Minimum Product Version: 5.2.0
 
 This app integrates with an instance of Symantec Messaging Gateway to perform containment and corrective actions
@@ -21,19 +21,19 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the supplied credentials with the SMG server \
-[blocklist email](#action-blocklist-email) - Add an email to the bad sender list \
-[unblocklist email](#action-unblocklist-email) - Remove an email from the bad sender list \
-[blocklist domain](#action-blocklist-domain) - Add a domain to the bad sender list \
-[unblocklist domain](#action-unblocklist-domain) - Remove a domain from the bad sender list \
-[blocklist ip](#action-blocklist-ip) - Add an IP to the bad sender list \
+[test connectivity](#action-test-connectivity) - Validate the supplied credentials with the SMG server <br>
+[blocklist email](#action-blocklist-email) - Add an email to the bad sender list <br>
+[unblocklist email](#action-unblocklist-email) - Remove an email from the bad sender list <br>
+[blocklist domain](#action-blocklist-domain) - Add a domain to the bad sender list <br>
+[unblocklist domain](#action-unblocklist-domain) - Remove a domain from the bad sender list <br>
+[blocklist ip](#action-blocklist-ip) - Add an IP to the bad sender list <br>
 [unblocklist ip](#action-unblocklist-ip) - Remove an IP from the bad sender list
 
 ## action: 'test connectivity'
 
 Validate the supplied credentials with the SMG server
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -48,7 +48,7 @@ No Output
 
 Add an email to the bad sender list
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action will add an email address to the list of <b>Local Bad Sender Domains</b>.
@@ -75,7 +75,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Remove an email from the bad sender list
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action will remove an email address from the list of <b>Local Bad Sender Domains</b>.
@@ -102,7 +102,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add a domain to the bad sender list
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action will add a domain to the list of <b>Local Bad Sender Domains</b>.
@@ -129,7 +129,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Remove a domain from the bad sender list
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action will remove a domain from the list of <b>Local Bad Sender Domains</b>.
@@ -156,7 +156,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Add an IP to the bad sender list
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action will add an IP address to the list of <b>Local Bad Sender IPs</b>.
@@ -183,7 +183,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Remove an IP from the bad sender list
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action will remove an IP address from the list of <b>Local Bad Sender IPs</b>.
@@ -210,7 +210,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 * Remove beautifulsoup4 from requirements.txt
 * Enable TLS certificate verification by default
 * Send login credentials in the request body and redact them from connection errors
+* Fail blocklist actions when SMG reports an error in an HTTP 200 response

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Remove beautifulsoup4 from requirements.txt
+* Enable TLS certificate verification by default

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Remove beautifulsoup4 from requirements.txt
 * Enable TLS certificate verification by default
+* Send login credentials in the request body and redact them from connection errors

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Enable TLS certificate verification by default
 * Send login credentials in the request body and redact them from connection errors
 * Fail blocklist actions when SMG reports an error in an HTTP 200 response
+* Bound the unblocklist member-list page walk

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Send login credentials in the request body and redact them from connection errors
 * Fail blocklist actions when SMG reports an error in an HTTP 200 response
 * Bound the unblocklist member-list page walk
+* Match exact blocklist members before deletion

--- a/smg.json
+++ b/smg.json
@@ -31,7 +31,7 @@
         "verify_server_cert": {
             "description": "Verify Server Certificate",
             "data_type": "boolean",
-            "default": false,
+            "default": true,
             "order": 1
         },
         "username": {

--- a/smg.json
+++ b/smg.json
@@ -9,7 +9,7 @@
     "product_name": "Messaging Gateway",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2018-2025 Splunk Inc.",
+    "license": "Copyright (c) 2018-2026 Splunk Inc.",
     "app_version": "2.0.8",
     "utctime_updated": "2025-08-01T20:39:08.212870Z",
     "package_name": "phantom_symantecmessaginggateway",
@@ -545,5 +545,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -1,6 +1,6 @@
 # File: smg_connector.py
 #
-# Copyright (c) 2018-2025 Splunk Inc.
+# Copyright (c) 2018-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ class SymantecMessagingGatewayConnector(BaseConnector):
             self.debug_print("Login Failed")
             return action_result.get_status()
 
-        ret_val, resp = self._make_rest_call("/reputation/sender-group/viewSenderGroup.do?view=badSenders", action_result)
+        ret_val, _resp = self._make_rest_call("/reputation/sender-group/viewSenderGroup.do?view=badSenders", action_result)
         if phantom.is_fail(ret_val):
             return ret_val
 
@@ -161,21 +161,21 @@ class SymantecMessagingGatewayConnector(BaseConnector):
             sender_group = "1|3"
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "view": "badSenders", "selectedSenderGroups": sender_group}
-        ret_val, resp = self._make_rest_call("/reputation/sender-group/viewSenderGroup.do", action_result, params=params)
+        ret_val, _resp = self._make_rest_call("/reputation/sender-group/viewSenderGroup.do", action_result, params=params)
         if phantom.is_fail(ret_val):
             return ret_val
 
-        ret_val, resp = self._make_rest_call("/reputation/sender-group/addSender.do", action_result, params=params)
+        ret_val, _resp = self._make_rest_call("/reputation/sender-group/addSender.do", action_result, params=params)
         if phantom.is_fail(ret_val):
             return ret_val
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "addEditSenders": item, "view": "badSenders"}
-        ret_val, resp = self._make_rest_call("/reputation/sender-group/saveSender.do", action_result, params=params)
+        ret_val, _resp = self._make_rest_call("/reputation/sender-group/saveSender.do", action_result, params=params)
         if phantom.is_fail(ret_val):
             return ret_val
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "view": "badSenders"}
-        ret_val, resp = self._make_rest_call("/reputation/sender-group/saveGroup.do", action_result, params=params)
+        ret_val, _resp = self._make_rest_call("/reputation/sender-group/saveGroup.do", action_result, params=params)
         if phantom.is_fail(ret_val):
             return ret_val
 

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -91,7 +91,7 @@ class SymantecMessagingGatewayConnector(BaseConnector):
         url = self._base_url + endpoint
 
         try:
-            r = request_func(url, data=data, headers=headers, verify=config.get("verify_server_cert", False), params=params)
+            r = request_func(url, data=data, headers=headers, verify=config.get("verify_server_cert", True), params=params)
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)
 

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -25,6 +25,7 @@ from phantom.base_connector import BaseConnector
 
 
 DEFAULT_REQUEST_TIMEOUT = 30  # in seconds
+MAX_MEMBER_LIST_PAGES = 1000
 
 
 class RetVal(tuple):
@@ -245,6 +246,12 @@ class SymantecMessagingGatewayConnector(BaseConnector):
         cur_page = 1
 
         while True:
+            if cur_page > MAX_MEMBER_LIST_PAGES:
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Exceeded the maximum of {MAX_MEMBER_LIST_PAGES} member-list pages without finding the item",
+                )
+
             soup = BeautifulSoup(resp.text, "html.parser")
             member_table = soup.find("table", {"id": "membersList"})
             if not member_table:
@@ -267,6 +274,8 @@ class SymantecMessagingGatewayConnector(BaseConnector):
                 break
 
             next_button = soup.find("button", {"id": "nextButton"})
+            if next_button is None:
+                return action_result.set_status(phantom.APP_ERROR, "Could not determine whether another member-list page exists")
             if "disabled" in next_button.attrs:
                 break
 

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -93,7 +93,14 @@ class SymantecMessagingGatewayConnector(BaseConnector):
         try:
             r = request_func(url, data=data, headers=headers, verify=config.get("verify_server_cert", True), params=params)
         except Exception as e:
-            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {e!s}"), resp_json)
+            error = str(e)
+            password = config.get("password")
+            if password:
+                password = str(password)
+                error = error.replace(requests.utils.quote(password, safe=""), "********")
+                error = error.replace(password, "********")
+            error = error.replace("{", "{{").replace("}", "}}")
+            return RetVal(action_result.set_status(phantom.APP_ERROR, f"Error Connecting to server. Details: {error}"), resp_json)
 
         if not r:
             return self._process_html_response(r, action_result)
@@ -116,9 +123,9 @@ class SymantecMessagingGatewayConnector(BaseConnector):
 
         config = self.get_config()
 
-        params = {"lastlogin": lastlogin, "username": config["username"], "password": config["password"]}
+        data = {"lastlogin": lastlogin, "username": config["username"], "password": config["password"]}
 
-        ret_val, resp = self._make_rest_call("/login.do", action_result, params=params)
+        ret_val, resp = self._make_rest_call("/login.do", action_result, data=data, method="post")
 
         if phantom.is_fail(ret_val):
             return ret_val

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -107,6 +107,24 @@ class SymantecMessagingGatewayConnector(BaseConnector):
 
         return RetVal(phantom.APP_SUCCESS, r)
 
+    def _verify_ui_response(self, response, action_result, operation):
+        """Fail when the SMG UI reports an error inside an HTTP 200 response."""
+        try:
+            soup = BeautifulSoup(response.text, "html.parser")
+        except Exception as e:
+            return action_result.set_status(phantom.APP_ERROR, f"Could not parse the server response while {operation}: {e!s}")
+
+        if soup.find("input", {"name": "lastlogin"}) is not None:
+            return action_result.set_status(phantom.APP_ERROR, f"Session expired while {operation}: server returned the login page")
+
+        error_tag = soup.select_one(".errorMessage, .errorMessageText")
+        if error_tag is not None:
+            error_text = error_tag.get_text(" ", strip=True) or "unspecified error"
+            error_text = error_text.replace("{", "{{").replace("}", "}}")
+            return action_result.set_status(phantom.APP_ERROR, f"Server rejected the request while {operation}: {error_text}")
+
+        return phantom.APP_SUCCESS
+
     def _login(self, action_result):
         self.debug_print("Attempting login")
 
@@ -177,12 +195,18 @@ class SymantecMessagingGatewayConnector(BaseConnector):
             return ret_val
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "addEditSenders": item, "view": "badSenders"}
-        ret_val, _resp = self._make_rest_call("/reputation/sender-group/saveSender.do", action_result, params=params)
+        ret_val, resp = self._make_rest_call("/reputation/sender-group/saveSender.do", action_result, params=params)
+        if phantom.is_fail(ret_val):
+            return ret_val
+        ret_val = self._verify_ui_response(resp, action_result, "saving the sender entry")
         if phantom.is_fail(ret_val):
             return ret_val
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "view": "badSenders"}
-        ret_val, _resp = self._make_rest_call("/reputation/sender-group/saveGroup.do", action_result, params=params)
+        ret_val, resp = self._make_rest_call("/reputation/sender-group/saveGroup.do", action_result, params=params)
+        if phantom.is_fail(ret_val):
+            return ret_val
+        ret_val = self._verify_ui_response(resp, action_result, "saving the sender group")
         if phantom.is_fail(ret_val):
             return ret_val
 
@@ -270,9 +294,15 @@ class SymantecMessagingGatewayConnector(BaseConnector):
         ret_val, resp = self._make_rest_call("/reputation/sender-group/deleteSender.do", action_result, params=params)
         if phantom.is_fail(ret_val):
             return ret_val
+        ret_val = self._verify_ui_response(resp, action_result, "deleting the sender entry")
+        if phantom.is_fail(ret_val):
+            return ret_val
 
         params = {"symantec.brightmail.key.TOKEN": self._token, "view": "badSenders"}
         ret_val, resp = self._make_rest_call("/reputation/sender-group/saveGroup.do", action_result, params=params)
+        if phantom.is_fail(ret_val):
+            return ret_val
+        ret_val = self._verify_ui_response(resp, action_result, "saving the sender group")
         if phantom.is_fail(ret_val):
             return ret_val
 

--- a/smg_connector.py
+++ b/smg_connector.py
@@ -258,11 +258,12 @@ class SymantecMessagingGatewayConnector(BaseConnector):
                 return action_result.set_status(phantom.APP_ERROR, "Could not find member list table")
 
             item_id = None
-            member_tags = soup.findAll("tr")
+            member_tags = member_table.find_all("tr")
             if not member_tags:
                 return action_result.set_status(phantom.APP_ERROR, "Could not find any items in bad senders list")
             for tag in member_tags:
-                if item in tag.text:
+                cell_values = [cell.get_text(" ", strip=True) for cell in tag.find_all("td")]
+                if item in cell_values:
                     checkbox = tag.find("input", {"name": "selectedGroupMembers"})
                     if not checkbox:
                         return action_result.set_status(phantom.APP_ERROR, "Could not find item ID")


### PR DESCRIPTION
### Bug Fixes

- Enable TLS certificate verification by default for new assets.
- Send SMG login credentials in the POST body and redact configured passwords from connection errors.
- Detect login redirects and SMG error banners returned with HTTP 200 responses.
- Bound member-list pagination and require exact blocklist member matches before deletion.

Tracks ESPM-5228 and PAPP-37982. Addresses PSAAS-30878, PSAAS-30999, PSAAS-31240, PSAAS-31745, PSAAS-32172, PSAAS-32297, PSAAS-32372, and PSAAS-32383.

This includes a breaking default change: newly created assets verify TLS certificates unless an administrator explicitly disables verification. Existing persisted asset settings are unchanged.

Validation: `pre-commit run --all-files`, Python compilation, JSON parsing, `git diff --check`, and signed-commit verification.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation changes are required.

### Other information

The supplied patches were treated as recommendations and adapted into five distinct connector-owned fixes.

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!